### PR TITLE
make example work out of the box

### DIFF
--- a/Documentation/install-helm-app.md
+++ b/Documentation/install-helm-app.md
@@ -63,7 +63,7 @@ After the CustomResourceDefinition and ClusterServiceVersion-v1 resources for th
 
 ```yaml
 cat <<EOF | kubectl create -f -
-apiVersion: example-apps.example.com/v1alpha1
+apiVersion: example.com/v1alpha1
 kind: ExampleApp
 metadata:
   name: sample-example

--- a/example-chart/templates/deployment.yaml
+++ b/example-chart/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.resource.spec.size }}
+  selector:
+    matchLabels:
+      resource: {{ .Values.resource.name }}
   template:
     metadata:
       labels:

--- a/example-chart/values.yaml
+++ b/example-chart/values.yaml
@@ -1,1 +1,1 @@
-image: nginx
+image: docker.io/nginx:latest


### PR DESCRIPTION
With this commit, several issues with the examples get fixed:

* The documentation uses the wrong `apiVersion`
`example-apps.example.com/v1alpha1`, it must be `example.com/v1alpha1`

* In the example Chart, the deployment object misses `spec.selector`

Fixes the following error:

```
release lostromos-sample-example failed: Deployment.apps "sample-example-hello" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"resource":"sample-example"}: `selector` does not match template `labels`]
```

* The specified nginx image needs to be fully qualified to work out of
the box

Fixes the following error:

```
Failed to inspect image "nginx": rpc error: code = Unknown desc = no registries configured while trying to pull an unqualified image
```