### PR TITLE
Update ClusterServiceVersion-v1 sa permissions

### DIFF
--- a/example-app-operator.v0.0.1.clusterserviceversion.yaml
+++ b/example-app-operator.v0.0.1.clusterserviceversion.yaml
@@ -20,6 +20,7 @@ spec:
           - example.com
           resources:
           - example-apps
+          - example-apps/finalizers
           verbs:
           - "*"
         - apiGroups:


### PR DESCRIPTION
The serviceaccount in the ClusterServiceVersion-v1 requires the example-apps/finalizers permission.  Otherwise creation of new instances of the example-app results in an error. This fix was suggested by @alecmerdler.

Fixes #7