### PR TITLE
pkg/helm/engine: Handle empty templates

### DIFF
--- a/helm-app-operator/pkg/helm/engine.go
+++ b/helm-app-operator/pkg/helm/engine.go
@@ -39,6 +39,10 @@ func (o *OwnerRefEngine) Render(chart *chart.Chart, values chartutil.Values) (ma
 		if err != nil {
 			return nil, err
 		}
+		if withOwner == "" {
+			logrus.Infof("skipping empty template: %s", fileName)
+			continue
+		}
 		ownedRenderedFiles[fileName] = withOwner
 	}
 	return ownedRenderedFiles, nil
@@ -49,6 +53,11 @@ func (o *OwnerRefEngine) addOwnerRefs(fileContents string) (string, error) {
 	parsed := chartutil.FromYaml(fileContents)
 	if errors, ok := parsed["Error"]; ok {
 		return "", fmt.Errorf("error parsing rendered template to add ownerrefs: %v", errors)
+	}
+
+	// Empty input
+	if len(parsed) == 0 {
+		return "", nil
 	}
 
 	unst, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&parsed)

--- a/helm-app-operator/pkg/helm/engine_test.go
+++ b/helm-app-operator/pkg/helm/engine_test.go
@@ -52,6 +52,8 @@ spec:
 	baseEngineOutput := map[string]string{
 		"template.yaml":  baseOut,
 		"template2.yaml": baseOut,
+		"empty.yaml":     "",
+		"comment.yaml":   "# This is empty",
 	}
 
 	engine := NewOwnerRefEngine(&mockEngine{out: baseEngineOutput}, ownerRefs)


### PR DESCRIPTION
The code adding `ownerReference` information to objects generated by
Helm templates would incorrectly handle 'empty' template renderings,
which are valid (and common) in charts, e.g. when certain objects are
only to be deployed based on some `values` (e.g. RBAC, `Ingress`es,...).

When such rendering occurred (an empty string, or maybe a string with
only some comment lines), the code would parse this as YAML, which would
yield an empty dictionary, then add a `metadata` field with the
`ownerReference` data in it, then pass this on to be deployed.

The above is of course flawed: we'd all of a sudden try to PUT an object
which has no `Kind`, no `apiVersion`,... only a `metadata` field, which
would then be rejected by the Kubernetes API server.

To fix this, empty template renderings are now skipped.