### PR TITLE
Fix Docker Build with Local Chart Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,7 @@ ENV API_VERSION $API_VERSION
 ENV KIND $KIND
 WORKDIR /
 COPY --from=builder /go/src/github.com/operator-framework/helm-app-operator-kit/helm-app-operator/bin/operator /operator
-ADD $HELM_CHART /chart.tgz 
-RUN mkdir /chart \
-  && tar -xzf /chart.tgz --strip-components=1 -C /chart \
-  && rm /chart.tgz
+ADD $HELM_CHART /chart
 ENV HELM_CHART /chart
 
 CMD ["/operator"]

--- a/examples/tomcat-operator/README.md
+++ b/examples/tomcat-operator/README.md
@@ -4,6 +4,7 @@ Simple Operator using the official [Tomcat Helm Chart](https://github.com/kubern
 
 Run the following from this directory:
 ```sh
+$ mkdir chart && wget -qO- https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz | tar -xzv --strip-components=1 -C ./chart
 $ docker build \
   --build-arg HELM_CHART=https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz \
   --build-arg API_VERSION=apache.org/v1alpha1 \


### PR DESCRIPTION
### Description

Updates the `Dockerfile` to only build with a local Helm Chart directory. Updates the example to download the remote chart and untar locally.

Addresses #27 