### PR TITLE
download vendor dependencies for helm-app-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG API_VERSION
 ARG KIND
 WORKDIR /go/src/github.com/operator-framework/helm-app-operator-kit/helm-app-operator
 COPY helm-app-operator .
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+RUN dep ensure -v
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/operator cmd/helm-app-operator/main.go
 RUN chmod +x bin/operator
 


### PR DESCRIPTION
#Description
Docker build won't pass due to dependency issue. Download vendor dependencies for helm-app-operator in Dockerfile. 

Addresses #17