### PR TITLE
Add Ability to Watch All Namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _output
 .kube
 .vscode
 .idea
+
+examples/tomcat-operator/chart

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ ARG API_VERSION
 ARG KIND
 WORKDIR /go/src/github.com/operator-framework/helm-app-operator-kit/helm-app-operator
 COPY helm-app-operator .
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-RUN dep ensure -v
+# FIXME(alecmerdler): Takes forever to download all dependencies
+# RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+# RUN dep ensure -v
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/operator cmd/helm-app-operator/main.go
 RUN chmod +x bin/operator
 

--- a/examples/tomcat-operator/README.md
+++ b/examples/tomcat-operator/README.md
@@ -6,10 +6,11 @@ Run the following from this directory:
 ```sh
 $ mkdir chart && wget -qO- https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz | tar -xzv --strip-components=1 -C ./chart
 $ docker build \
-  --build-arg HELM_CHART=https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz \
+  --build-arg HELM_CHART=./examples/tomcat-operator/chart \
   --build-arg API_VERSION=apache.org/v1alpha1 \
   --build-arg KIND=Tomcat \
   -t quay.io/<namespace>/tomcat-operator ../../
+$ docker push quay.io/<namespace>/tomcat-operator
 $ kubectl create -f crd.yaml
 $ kubectl create -n <operator-namespace> -f csv.yaml
 ```

--- a/examples/tomcat-operator/csv.yaml
+++ b/examples/tomcat-operator/csv.yaml
@@ -1,5 +1,5 @@
-apiVersion: app.coreos.com/v1alpha1
-kind: ClusterServiceVersion-v1
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
 metadata:
   name: tomcat-operator.v0.0.1
 spec:
@@ -76,9 +76,7 @@ spec:
                       fieldRef:
                         fieldPath: metadata.namespace
                   - name: WATCH_NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
+                    value: "*"
                   - name: MY_POD_NAME
                     valueFrom:
                       fieldRef:

--- a/helm-app-operator/cmd/helm-app-operator/main.go
+++ b/helm-app-operator/cmd/helm-app-operator/main.go
@@ -9,6 +9,7 @@ import (
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/storage"
 	"k8s.io/helm/pkg/storage/driver"
@@ -37,6 +38,9 @@ func main() {
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		logrus.Fatalf("Failed to get watch namespace: %v", err)
+	}
+	if namespace == "*" {
+		namespace = metav1.NamespaceAll
 	}
 	resyncPeriod := 5
 

--- a/helm-app-operator/deploy/operator.yaml
+++ b/helm-app-operator/deploy/operator.yaml
@@ -16,8 +16,3 @@ spec:
         - name: <chart>-operator
           image: quay.io/<namespace>/<chart>-operator
           imagePullPolicy: Always
-          env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace


### PR DESCRIPTION
### Description

Removes logic that constrains `helm-app-operator` from only watching custom resources in its own namespace.

Addresses https://jira.coreos.com/browse/ALM-710