### PR TITLE
Support multiple resources

### DIFF
--- a/helm-app-operator/Gopkg.lock
+++ b/helm-app-operator/Gopkg.lock
@@ -1336,6 +1336,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/cached",
     "k8s.io/client-go/rest",

--- a/helm-app-operator/cmd/manager/main.go
+++ b/helm-app-operator/cmd/manager/main.go
@@ -55,19 +55,20 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	// Dynamically load the helm installer based on the environment
-	gvk, installer, err := helm.NewInstallerFromEnv(storageBackend, tillerKubeClient)
+	installers, err := helm.NewInstallersFromEnv(storageBackend, tillerKubeClient)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
-	// Register the controller with the manager.
-	controller.Add(mgr, controller.WatchOptions{
-		Namespace:    namespace,
-		GVK:          gvk,
-		Installer:    installer,
-		ResyncPeriod: 5 * time.Second,
-	})
+	for gvk, installer := range installers {
+		// Register the controller with the manager.
+		controller.Add(mgr, controller.WatchOptions{
+			Namespace:    namespace,
+			GVK:          gvk,
+			Installer:    installer,
+			ResyncPeriod: 5 * time.Second,
+		})
+	}
 
 	logrus.Print("Starting the Cmd.")
 

--- a/helm-app-operator/pkg/helm/controller/controller.go
+++ b/helm-app-operator/pkg/helm/controller/controller.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crthandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	appv1alpha1 "github.com/operator-framework/helm-app-operator-kit/helm-app-operator/pkg/apis/app/v1alpha1"
 	"github.com/operator-framework/helm-app-operator-kit/helm-app-operator/pkg/helm"
 )
 
@@ -39,8 +39,7 @@ func Add(mgr manager.Manager, options WatchOptions) {
 	}
 
 	// Register the GVK with the schema
-	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &appv1alpha1.HelmApp{})
-	mgr.GetScheme().AddKnownTypeWithName(options.GVK.GroupVersion().WithKind(options.GVK.Kind+"List"), &appv1alpha1.HelmAppList{})
+	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 	metav1.AddToGroupVersion(mgr.GetScheme(), options.GVK.GroupVersion())
 
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(options.GVK.Kind))
@@ -49,7 +48,8 @@ func Add(mgr manager.Manager, options WatchOptions) {
 		logrus.Fatal(err)
 	}
 
-	o := &appv1alpha1.HelmApp{}
+	o := &unstructured.Unstructured{}
+	o.SetGroupVersionKind(options.GVK)
 	if err := c.Watch(&source.Kind{Type: o}, &crthandler.EnqueueRequestForObject{}); err != nil {
 		logrus.Fatal(err)
 	}

--- a/helm-app-operator/pkg/helm/controller/controller.go
+++ b/helm-app-operator/pkg/helm/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crthandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -32,10 +33,11 @@ func Add(mgr manager.Manager, options WatchOptions) {
 		options.ResyncPeriod = time.Minute
 	}
 	r := &helmOperatorReconciler{
-		Client:       mgr.GetClient(),
-		GVK:          options.GVK,
-		Installer:    options.Installer,
-		ResyncPeriod: options.ResyncPeriod,
+		Client:               mgr.GetClient(),
+		GVK:                  options.GVK,
+		Installer:            options.Installer,
+		ResyncPeriod:         options.ResyncPeriod,
+		lastResourceVersions: map[types.NamespacedName]string{},
 	}
 
 	// Register the GVK with the schema

--- a/helm-app-operator/pkg/helm/controller/reconcile.go
+++ b/helm-app-operator/pkg/helm/controller/reconcile.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	appv1alpha1 "github.com/operator-framework/helm-app-operator-kit/helm-app-operator/pkg/apis/app/v1alpha1"
 	"github.com/operator-framework/helm-app-operator-kit/helm-app-operator/pkg/helm"
 )
 
@@ -28,11 +28,11 @@ var lastResourceVersion string
 func (r helmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	logrus.Infof("processing %s", request.NamespacedName)
 
-	o := &appv1alpha1.HelmApp{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, o)
+	o := &unstructured.Unstructured{}
 	o.SetGroupVersionKind(r.GVK)
-	o.SetNamespace(request.Namespace)
+	err := r.Client.Get(context.TODO(), request.NamespacedName, o)
 	o.SetName(request.Name)
+	o.SetNamespace(request.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			_, err = r.Installer.UninstallRelease(o)

--- a/helm-app-operator/pkg/helm/controller/reconcile.go
+++ b/helm-app-operator/pkg/helm/controller/reconcile.go
@@ -28,18 +28,51 @@ type helmOperatorReconciler struct {
 	mutex                sync.RWMutex
 }
 
+const (
+	finalizer = "uninstall-helm-release"
+)
+
 func (r *helmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	logrus.Infof("processing %s", request.NamespacedName)
 
 	o := &unstructured.Unstructured{}
 	o.SetGroupVersionKind(r.GVK)
 	err := r.Client.Get(context.TODO(), request.NamespacedName, o)
-	o.SetName(request.Name)
-	o.SetNamespace(request.Namespace)
+	if apierrors.IsNotFound(err) {
+		return reconcile.Result{}, nil
+	}
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err = r.Installer.UninstallRelease(o)
+		return reconcile.Result{}, err
+	}
+
+	deleted := o.GetDeletionTimestamp() != nil
+	pendingFinalizers := o.GetFinalizers()
+	if !deleted && !contains(pendingFinalizers, finalizer) {
+		logrus.Debugf("adding finalizer %s to resource", finalizer)
+		finalizers := append(pendingFinalizers, finalizer)
+		o.SetFinalizers(finalizers)
+		err := r.Client.Update(context.TODO(), o)
+		return reconcile.Result{}, err
+	}
+	if deleted {
+		if !contains(pendingFinalizers, finalizer) {
+			logrus.Info("resouce is terminated, skipping reconciliation")
+			return reconcile.Result{}, nil
 		}
+
+		_, err = r.Installer.UninstallRelease(o)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		finalizers := []string{}
+		for _, pendingFinalizer := range pendingFinalizers {
+			if pendingFinalizer != finalizer {
+				finalizers = append(finalizers, pendingFinalizer)
+			}
+		}
+		o.SetFinalizers(finalizers)
+		err := r.Client.Update(context.TODO(), o)
 		return reconcile.Result{}, err
 	}
 
@@ -63,6 +96,15 @@ func (r *helmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile
 	r.setLastResourceVersion(request.NamespacedName, o.GetResourceVersion())
 
 	return reconcile.Result{RequeueAfter: r.ResyncPeriod}, nil
+}
+
+func contains(l []string, s string) bool {
+	for _, elem := range l {
+		if elem == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *helmOperatorReconciler) getLastResourceVersion(n types.NamespacedName) (string, bool) {

--- a/helm-app-operator/pkg/helm/helm.go
+++ b/helm-app-operator/pkg/helm/helm.go
@@ -2,7 +2,9 @@ package helm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -26,6 +28,13 @@ import (
 )
 
 const (
+	// HelmChartWatchesEnvVar is the environment variable for a YAML
+	// configuration file containing mappings of GVKs to helm charts. Use of
+	// this environment variable overrides the watch configuration provided
+	// by API_VERSION, KIND, and HELM_CHART, and it allows users to configure
+	// multiple watches, each with a different chart.
+	HelmChartWatchesEnvVar = "HELM_CHART_WATCHES"
+
 	// APIVersionEnvVar is the environment variable for the group and version
 	// to be watched using the format `<group>/<version>`
 	// (e.g. "example.com/v1alpha1").
@@ -40,7 +49,8 @@ const (
 	// API_VERSION and KIND environment variables.
 	HelmChartEnvVar = "HELM_CHART"
 
-	operatorName = "helm-app-operator"
+	operatorName                = "helm-app-operator"
+	defaultHelmChartWatchesFile = "/opt/helm/watches.yaml"
 )
 
 // Installer can install and uninstall Helm releases given a custom resource
@@ -56,14 +66,21 @@ type installer struct {
 	chart            *cpb.Chart
 }
 
+type watch struct {
+	Group   string `yaml:"group"`
+	Version string `yaml:"version"`
+	Kind    string `yaml:"kind"`
+	Chart   string `yaml:"chart"`
+}
+
 // NewInstaller returns a new Helm installer capable of installing and uninstalling releases.
 func NewInstaller(storageBackend *storage.Storage, tillerKubeClient *kube.Client, chart *cpb.Chart) Installer {
 	return installer{storageBackend, tillerKubeClient, chart}
 }
 
-// NewInstallerFromEnv returns a GVK and installer based on configuration provided
+// newInstallerFromEnv returns a GVK and installer based on configuration provided
 // in the environment.
-func NewInstallerFromEnv(storageBackend *storage.Storage, tillerKubeClient *kube.Client) (schema.GroupVersionKind, Installer, error) {
+func newInstallerFromEnv(storageBackend *storage.Storage, tillerKubeClient *kube.Client) (schema.GroupVersionKind, Installer, error) {
 	apiVersion := os.Getenv(APIVersionEnvVar)
 	kind := os.Getenv(KindEnvVar)
 	chartDir := os.Getenv(HelmChartEnvVar)
@@ -75,30 +92,105 @@ func NewInstallerFromEnv(storageBackend *storage.Storage, tillerKubeClient *kube
 	}
 	gvk = gv.WithKind(kind)
 
-	// Verify the GVK. In general, GVKs without groups are valid. However,
-	// a GVK without a group will most likely fail with a more descriptive
-	// error later in the initialization process.
-	if gvk.Version == "" {
-		return gvk, nil, fmt.Errorf("invalid %s: version must not be empty", APIVersionEnvVar)
-	}
-	if gvk.Kind == "" {
-		return gvk, nil, fmt.Errorf("invalid %s: kind must not be empty", KindEnvVar)
+	if err := verifyGVK(gvk); err != nil {
+		return gvk, nil, fmt.Errorf("invalid GVK: %s: %s", gvk, err)
 	}
 
-	// Verify that the Helm chart directory is valid.
-	if chartDir == "" {
-		return gvk, nil, fmt.Errorf("invalid %s: must not be empty", HelmChartEnvVar)
-	}
-	if stat, err := os.Stat(chartDir); err != nil || !stat.IsDir() {
-		return gvk, nil, fmt.Errorf("invalid %s: %s is not a directory", HelmChartEnvVar, chartDir)
-	}
-	chart, err := chartutil.LoadDir(chartDir)
+	chart, err := loadChart(chartDir)
 	if err != nil {
-		return gvk, nil, fmt.Errorf("invalid %s: failed loading chart from %s: %s", HelmChartEnvVar, chartDir, err)
+		return gvk, nil, fmt.Errorf("invalid chart directory: failed to load chart from %s: %s", chartDir, err)
 	}
 
 	installer := NewInstaller(storageBackend, tillerKubeClient, chart)
 	return gvk, installer, nil
+}
+
+// NewInstallersFromEnv returns a map of installers, keyed by GVK, based on
+// configuration provided in the environment.
+func NewInstallersFromEnv(storageBackend *storage.Storage, tillerKubeClient *kube.Client) (map[schema.GroupVersionKind]Installer, error) {
+	if watchesFile, ok := getWatchesFile(); ok {
+		return NewInstallersFromFile(storageBackend, tillerKubeClient, watchesFile)
+	}
+	gvk, installer, err := newInstallerFromEnv(storageBackend, tillerKubeClient)
+	if err != nil {
+		return nil, err
+	}
+	return map[schema.GroupVersionKind]Installer{gvk: installer}, nil
+}
+
+// NewInstallersFromFile reads the config file at the provided path and returns a map
+// of installers, keyed by each GVK in the config.
+func NewInstallersFromFile(storageBackend *storage.Storage, tillerKubeClient *kube.Client, path string) (map[schema.GroupVersionKind]Installer, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %s", err)
+	}
+	watches := []watch{}
+	err = yaml.Unmarshal(b, &watches)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %s", err)
+	}
+
+	m := map[schema.GroupVersionKind]Installer{}
+	for _, w := range watches {
+		gvk := schema.GroupVersionKind{
+			Group:   w.Group,
+			Version: w.Version,
+			Kind:    w.Kind,
+		}
+
+		if err := verifyGVK(gvk); err != nil {
+			return nil, fmt.Errorf("invalid GVK: %s: %s", gvk, err)
+		}
+
+		chart, err := loadChart(w.Chart)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load chart from %s: %s", w.Chart, err)
+		}
+
+		if _, ok := m[gvk]; ok {
+			return nil, fmt.Errorf("duplicate GVK: %s", gvk)
+		}
+		m[gvk] = NewInstaller(storageBackend, tillerKubeClient, chart)
+	}
+	return m, nil
+}
+
+func verifyGVK(gvk schema.GroupVersionKind) error {
+	// A GVK without a group is valid. Certain scenarios may cause a GVK
+	// without a group to fail in other ways later in the initialization
+	// process.
+	if gvk.Version == "" {
+		return errors.New("version must not be empty")
+	}
+	if gvk.Kind == "" {
+		return errors.New("kind must not be empty")
+	}
+	return nil
+}
+
+func loadChart(path string) (*cpb.Chart, error) {
+	if path == "" {
+		return nil, errors.New("path must not be empty")
+	}
+	if stat, err := os.Stat(path); err != nil || !stat.IsDir() {
+		return nil, errors.New("path is not a directory")
+	}
+	return chartutil.LoadDir(path)
+}
+
+func getWatchesFile() (string, bool) {
+	// If the watches env variable is set (even if it's an empty string), use it
+	// since the user explicitly set it.
+	if watchesFile, ok := os.LookupEnv(HelmChartWatchesEnvVar); ok {
+		return watchesFile, true
+	}
+
+	// Next, check if the default watches file is present. If so, use it.
+	if _, err := os.Stat(defaultHelmChartWatchesFile); err == nil {
+		return defaultHelmChartWatchesFile, true
+	}
+	return "", false
 }
 
 // InstallRelease accepts a custom resource, installs a Helm release using Tiller,


### PR DESCRIPTION
This PR mostly (but not completely) supersedes #43. It:
* Updates the controller and installer components to expect unstructured objects.
* Fixes a bug in the reconcilier that prevented multiple instances of a resource from being correctly reconciled due to the use of a global variable to track `lastResourceVersion`.
* Adds a finalizer and associated logic, which is a better way to handle uninstalling releases.
* Adds new functions to support watches and reconciliation for multiple resource types.

Each of these changes is contained in its own commit on this branch.