### PR TITLE
Reconcile resources

### DIFF
--- a/helm-app-operator/Gopkg.lock
+++ b/helm-app-operator/Gopkg.lock
@@ -1360,6 +1360,7 @@
     "k8s.io/helm/pkg/tiller",
     "k8s.io/helm/pkg/tiller/environment",
     "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+    "k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/helm-app-operator/Gopkg.lock
+++ b/helm-app-operator/Gopkg.lock
@@ -1357,6 +1357,7 @@
     "k8s.io/helm/pkg/proto/hapi/services",
     "k8s.io/helm/pkg/storage",
     "k8s.io/helm/pkg/storage/driver",
+    "k8s.io/helm/pkg/storage/errors",
     "k8s.io/helm/pkg/tiller",
     "k8s.io/helm/pkg/tiller/environment",
     "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",

--- a/helm-app-operator/pkg/helm/controller/controller.go
+++ b/helm-app-operator/pkg/helm/controller/controller.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crthandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -33,11 +32,10 @@ func Add(mgr manager.Manager, options WatchOptions) {
 		options.ResyncPeriod = time.Minute
 	}
 	r := &helmOperatorReconciler{
-		Client:               mgr.GetClient(),
-		GVK:                  options.GVK,
-		Installer:            options.Installer,
-		ResyncPeriod:         options.ResyncPeriod,
-		lastResourceVersions: map[types.NamespacedName]string{},
+		Client:       mgr.GetClient(),
+		GVK:          options.GVK,
+		Installer:    options.Installer,
+		ResyncPeriod: options.ResyncPeriod,
 	}
 
 	// Register the GVK with the schema

--- a/helm-app-operator/pkg/helm/controller/reconcile.go
+++ b/helm-app-operator/pkg/helm/controller/reconcile.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -11,7 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -23,9 +21,6 @@ type helmOperatorReconciler struct {
 	GVK          schema.GroupVersionKind
 	Installer    helm.Installer
 	ResyncPeriod time.Duration
-
-	lastResourceVersions map[types.NamespacedName]string
-	mutex                sync.RWMutex
 }
 
 const (
@@ -76,24 +71,19 @@ func (r *helmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	lastResourceVersion, ok := r.getLastResourceVersion(request.NamespacedName)
-	if ok && o.GetResourceVersion() == lastResourceVersion {
-		logrus.Infof("skipping %s because resource version has not changed", request.NamespacedName)
-		return reconcile.Result{RequeueAfter: r.ResyncPeriod}, nil
-	}
-
-	updatedResource, err := r.Installer.InstallRelease(o)
+	updatedResource, needsUpdate, err := r.Installer.ReconcileRelease(o)
 	if err != nil {
 		logrus.Errorf(err.Error())
 		return reconcile.Result{}, err
 	}
 
-	err = r.Client.Update(context.TODO(), updatedResource)
-	if err != nil {
-		logrus.Errorf(err.Error())
-		return reconcile.Result{}, fmt.Errorf("failed to update custom resource status: %v", err)
+	if needsUpdate {
+		err = r.Client.Update(context.TODO(), updatedResource)
+		if err != nil {
+			logrus.Errorf(err.Error())
+			return reconcile.Result{}, fmt.Errorf("failed to update custom resource status: %v", err)
+		}
 	}
-	r.setLastResourceVersion(request.NamespacedName, o.GetResourceVersion())
 
 	return reconcile.Result{RequeueAfter: r.ResyncPeriod}, nil
 }
@@ -105,17 +95,4 @@ func contains(l []string, s string) bool {
 		}
 	}
 	return false
-}
-
-func (r *helmOperatorReconciler) getLastResourceVersion(n types.NamespacedName) (string, bool) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	v, ok := r.lastResourceVersions[n]
-	return v, ok
-}
-
-func (r *helmOperatorReconciler) setLastResourceVersion(n types.NamespacedName, v string) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.lastResourceVersions[n] = v
 }

--- a/helm-app-operator/pkg/helm/engine.go
+++ b/helm-app-operator/pkg/helm/engine.go
@@ -34,13 +34,13 @@ func (o *OwnerRefEngine) Render(chart *chart.Chart, values chartutil.Values) (ma
 		if !strings.HasSuffix(fileName, ".yaml") {
 			continue
 		}
-		logrus.Infof("adding ownerrefs to file: %s", fileName)
+		logrus.Debugf("adding ownerrefs to file: %s", fileName)
 		withOwner, err := o.addOwnerRefs(renderedFile)
 		if err != nil {
 			return nil, err
 		}
 		if withOwner == "" {
-			logrus.Infof("skipping empty template: %s", fileName)
+			logrus.Debugf("skipping empty template: %s", fileName)
 			continue
 		}
 		ownedRenderedFiles[fileName] = withOwner

--- a/helm-app-operator/pkg/helm/helm.go
+++ b/helm-app-operator/pkg/helm/helm.go
@@ -335,7 +335,10 @@ func (c installer) reconcileRelease(r *unstructured.Unstructured, expectedManife
 		}
 		helper := resource.NewHelper(expected.Client, expected.Mapping)
 		_, err = helper.Create(expected.Namespace, true, expected.Object)
-		if err == nil || !apierrors.IsAlreadyExists(err) {
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("create error: %s", err)
 		}
 


### PR DESCRIPTION
This PR add several improvements. It:
* Adds logic to perform resource reconciliation when a CR has not changed.
* Uses the state of the CR's release status to determine whether an installation, update, or reconciliation should be performed.
* Fixes an issue with the helm reconciler chart configuration, which could be mutated across different CR instances.
* Improves error messages and logging.
* Makes changes to several installer helper functions for clarity and error handling.
