### PR TITLE
Improve release name uniqueness and ownership

### DIFF
--- a/helm-app-operator/Gopkg.lock
+++ b/helm-app-operator/Gopkg.lock
@@ -427,6 +427,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:23ffae70055f9e10c20f42157f8bcd9fa00fc5241ab453eaac3850541639ad0d"
+  name = "github.com/martinlindhe/base36"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "5cda0030da1725952be91a1223090c4ecef8dfb2"
+
+[[projects]]
+  branch = "master"
   digest = "1:0e9bfc47ab9941ecc3344e580baca5deb4091177e84dd9773b48b38ec26b93d5"
   name = "github.com/mattbaird/jsonpatch"
   packages = ["."]
@@ -1324,8 +1332,10 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/martinlindhe/base36",
     "github.com/operator-framework/operator-sdk/pkg/util/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/pborman/uuid",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/helm-app-operator/pkg/helm/helm.go
+++ b/helm-app-operator/pkg/helm/helm.go
@@ -70,11 +70,6 @@ const (
 	HelmChartEnvVar = "HELM_CHART"
 
 	defaultHelmChartWatchesFile = "/opt/helm/watches.yaml"
-
-	annotationReleaseName          = "helm.operator-sdk/release-name"
-	annotationUseNameAsReleaseName = "helm.operator-sdk/use-name-as-release-name"
-
-	valueResourceUID = "helm.operator-sdk/resource-uid"
 )
 
 // Installer can install and uninstall Helm releases given a custom resource
@@ -224,22 +219,7 @@ func (c installer) ReconcileRelease(r *unstructured.Unstructured) (*unstructured
 	if err != nil {
 		return r, needsUpdate, fmt.Errorf("failed to parse values: %s", err)
 	}
-	uid := cpb.Value{
-		Value: string(r.GetUID()),
-	}
-	config := &cpb.Config{
-		Raw: string(cr),
-
-		// Store the resource UID as a config value in the release.
-		// This is helpful to determine release ownership, even in the
-		// case where a status update for the release fails. By setting
-		// it as a config value, it also gets saved in the storage
-		// backend used to record releases as they are installed and
-		// updated.
-		Values: map[string]*cpb.Value{
-			valueResourceUID: &uid,
-		},
-	}
+	config := &cpb.Config{Raw: string(cr)}
 	logrus.Debugf("Using values: %s", config.GetRaw())
 
 	err = processRequirements(chart, config)
@@ -285,9 +265,6 @@ func (c installer) ReconcileRelease(r *unstructured.Unstructured) (*unstructured
 		needsUpdate = true
 		logrus.Infof("Installed release for %s release=%s", ResourceString(r), updatedRelease.GetName())
 
-	} else if !isReleaseOwner(r, latestRelease) {
-		// If this object is not the release owner, return an error.
-		return r, needsUpdate, fmt.Errorf("install error: release \"%s\" already exists", releaseName)
 	} else {
 		candidateRelease, err := c.getCandidateRelease(tiller, releaseName, chart, config)
 		if err != nil {
@@ -335,11 +312,6 @@ func (c installer) UninstallRelease(r *unstructured.Unstructured) (*unstructured
 	// If there is no history, the release has already been uninstalled,
 	// so there's nothing to do.
 	if len(h) == 0 {
-		return r, nil
-	}
-
-	// If this object is not the release owner, there's nothing to do.
-	if !isReleaseOwner(r, h[0]) {
 		return r, nil
 	}
 
@@ -494,24 +466,8 @@ func (c installer) tillerRendererForCR(r *unstructured.Unstructured) *tiller.Rel
 }
 
 func getReleaseName(r *unstructured.Unstructured) string {
-	status := v1alpha1.StatusFor(r)
-	if status.Release != nil {
-		return status.Release.GetName()
-	}
-	if v, ok := r.GetAnnotations()[annotationReleaseName]; ok {
-		return v
-	}
-	if v, ok := r.GetAnnotations()[annotationUseNameAsReleaseName]; ok && v == "true" {
-		return r.GetName()
-	}
-
-	// An empty release name will be populated automatically by tiller
-	// during installation
-	return ""
-}
-
-func isReleaseOwner(r *unstructured.Unstructured, rel *release.Release) bool {
-	return string(r.GetUID()) == rel.GetConfig().GetValues()[valueResourceUID].GetValue()
+	shortUID := strings.Replace(string(r.GetUID()), "-", "", -1)[:8]
+	return fmt.Sprintf("%s-%s", r.GetName(), shortUID)
 }
 
 func notFoundErr(err error) bool {


### PR DESCRIPTION
**Description of change**
This PR updates the way the release name is determined for a CR, first by checking new annotations that allow users to customize the release name. If no annotations are set, it falls back to using a tiller-provided release name, which is guaranteed to be unique.

The PR also adds checks to ensure that a CR "owns" a release name before making changes for that release. This prevents two CRs from updating each others releases and prevents a CR from uninstalling another CR's release.

**Motivation for change**
See #49 for details