### PR TITLE
Fixing Dockerfile and tomcat-operator example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,12 @@ ENV API_VERSION $API_VERSION
 ENV KIND $KIND
 WORKDIR /
 COPY --from=builder /go/src/github.com/operator-framework/helm-app-operator-kit/helm-app-operator/bin/operator /operator
-ADD $HELM_CHART /chart
+RUN apk add -U curl && \
+    mkdir chart  && \
+    curl "$HELM_CHART" | tar -xzv --strip-components=1 -C ./chart && \
+    apk del curl && \
+    rm -rf /var/cache/apk/*
+
 ENV HELM_CHART /chart
 
 CMD ["/operator"]

--- a/examples/tomcat-operator/.gitignore
+++ b/examples/tomcat-operator/.gitignore
@@ -1,0 +1,2 @@
+/operator.yaml
+/csv.yaml

--- a/examples/tomcat-operator/README.md
+++ b/examples/tomcat-operator/README.md
@@ -1,15 +1,43 @@
 # Example: Tomcat Operator
 
-Simple Operator using the official [Tomcat Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/tomcat) and deployed using the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager).
+Simple Operator using the official [Tomcat Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/tomcat) and deployed directly or using the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager).
 
-Run the following from this directory:
+## Build and push the tomcat-operator container
+
 ```sh
-$ mkdir chart && wget -qO- https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz | tar -xzv --strip-components=1 -C ./chart
-$ docker build \
+export IMAGE=quay.io/<namespace>/tomcat-operator:v0.0.1
+docker build \
   --build-arg HELM_CHART=https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz \
   --build-arg API_VERSION=apache.org/v1alpha1 \
   --build-arg KIND=Tomcat \
-  -t quay.io/<namespace>/tomcat-operator ../../
-$ kubectl create -f crd.yaml
-$ kubectl create -n <operator-namespace> -f csv.yaml
+  -t $IMAGE ../../
+
+docker push $IMAGE
+```
+
+## Deploying the tomcat-operator to your cluster
+
+### As a deployment:
+
+```sh
+kubectl create -f crd.yaml
+kubectl create -n <operator-namespace> -f rbac.yaml
+
+sed "s|REPLACE_IMAGE|$IMAGE|" operator.yaml.template > operator.yaml
+kubectl create -n <operator-namespace> -f operator.yaml
+```
+
+### Using the Operator Lifecycle Manager:
+
+```sh
+kubectl create -f crd.yaml
+
+sed "s|REPLACE_IMAGE|$IMAGE|" csv.yaml.template > csv.yaml
+kubectl create -n <operator-namespace> -f csv.yaml
+```
+
+## Deploying an instance of tomcat
+
+```sh
+kubectl create -n <operator-namespace> -f cr.yaml
 ```

--- a/examples/tomcat-operator/csv.yaml.template
+++ b/examples/tomcat-operator/csv.yaml.template
@@ -68,7 +68,7 @@ spec:
             spec:
               containers:
                 - name: tomcat-operator-olm-owned
-                  image: quay.io/alecmerdler/tomcat-operator
+                  image: REPLACE_IMAGE
                   imagePullPolicy: Always
                   env:
                   - name: MY_POD_NAMESPACE

--- a/examples/tomcat-operator/operator.yaml.template
+++ b/examples/tomcat-operator/operator.yaml.template
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tomcat-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: tomcat-operator
+  template:
+    metadata:
+      labels:
+        name: tomcat-operator
+    spec:
+      containers:
+        - name: tomcat-operator
+          image: REPLACE_IMAGE
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/examples/tomcat-operator/rbac.yaml
+++ b/examples/tomcat-operator/rbac.yaml
@@ -1,0 +1,46 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tomcat-operator
+rules:
+- apiGroups:
+  - apache.org
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-tomcat-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: tomcat-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Description of change:**
Updating the root Dockerfile and tomcat-operator example manifests to align with this blog post: https://blog.openshift.com/make-a-kubernetes-operator-in-15-minutes-with-helm/

**Motivation for change:**
The repository and blog post have conflicting information, the result being a non-working example. This PR (in combination with some minor updates to the blog post) will fix that.