### PR TITLE
README.md: documenting build, config, and new features; refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,24 @@
-This project is a component of the [Operator Framework](https://github.com/operator-framework), an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way. Read more in the [introduction blog post](https://coreos.com/blog/introducing-operator-framework).
-
 # Helm App Operator Kit
 
-[![Docker Repository on Quay](https://quay.io/repository/operatorframework/helm-app-operator-ci/status "Docker Repository on Quay")](https://quay.io/repository/operatorframework/helm-app-operator-ci)
+This project is a component of the [Operator Framework](https://github.com/operator-framework), an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way. Read more in the [introduction blog post](https://coreos.com/blog/introducing-operator-framework).
 
-This repository serves as a template for easily creating managed stateless applications that run either Kubernetes Deployments or Helm charts. It was inspired by the [Lostromos project](https://github.com/wpengine/lostromos). The underlying Operator was created using the `operator-sdk new` command.
-
-## Installing a custom Helm-based app
+This repository serves as a template for easily creating managed stateless applications that run Helm charts. It was inspired by the [Lostromos project](https://github.com/wpengine/lostromos). The underlying Operator was created using the `operator-sdk new` command.
 
 While the [Operator Lifecycle Manager][olm-repo] can only manage Operators, not all applications require developers to write a custom Operator.
 The [Helm App Operator Kit][helm-sdk] makes it possible to leverage a pre-existing Helm chart to deploy Kubernetes resources as a unified application.
 
+## Clone the project
+
 ```sh
-git clone https://github.com/coreos/helm-app-operator-kit
+mkdir -p $GOPATH/src/github.com/operator-framework
+cd $GOPATH/src/github.com/operator-framework
+git clone https://github.com/operator-framework/helm-app-operator-kit
 cd helm-app-operator-kit
 ```
 
-### Prerequisites
+## Getting Started
 
-- Kubernetes 1.9+ cluster
-- `docker` client
-- `kubectl` client
-- Helm Chart
+See the [helm-app-operator](./helm-app-operator) subdirectory for more details about how to build and deploy a custom operator with Helm App Operator Kit or follow along with a simple [tomcat-operator](./examples/tomcat-operator) example.
 
-### Instructions
-
-1) Run the following:
-
-```sh
-$ git checkout git@github.com:operator-framework/helm-app-operator-kit.git && cd helm-app-operator-kit
-$ cd helm-app-operator && dep ensure && cd ..
-$ docker build -t quay.io/<namespace>/<chart>-operator --build-arg HELM_CHART=/path/to/helm/chart --build-arg API_VERSION=<group/version> --build-arg KIND=<Kind> .
-$ docker push quay.io/<namespace>/<chart>-operator
-```
-
-2) Modify the following Kubernetes YAML manifest files in `helm-app-operator/deploy`:
-
-File                          | Action
-------------------------------|--------------------------------------------------------------------------------------------------------
-`deploy/crd.yaml`             | Define your CRD (`kind`, `spec.version`, `spec.group` *must* match the `docker build` args)
-`deploy/cr.yaml`              | Make an instance of your custom resource (`kind`, `apiVersion` *must match the `docker build` args)
-`deploy/operator.yaml`        | Replace `<namespace>` and `<chart>` appropriately
-`deploy/rbac.yaml`            | Ensure the resources created by your chart are properly listed
-`deploy/olm-catalog/csv.yaml`             | Replace fields appropriately. Define RBAC in `spec.install.spec.permissions`. Ensure `spec.customresourcedefinitions.owned` correctly contains your CRD
-`deploy/olm-catalog/crd.yaml` | Define your CRD (`kind`, `spec.version`, `spec.group` *must* match the `docker build` args)
-
-3) Apply the manifests to your Kubernetes cluster (if using Operator Lifecycle Manager):
-
-```sh
-$ kubectl create -f helm-app-operator/deploy/olm-catalog/crd.yaml
-$ kubectl create -n <operator-namespace> -f helm-app-operator/deploy/olm-catalog/csv.yaml
-```
-
-Otherwise, manually create the RBAC and deployment resources:
-
-```sh
-$ kubectl create -f helm-app-operator/deploy/crd.yaml
-$ kubectl create -n <operator-namespace> -f helm-app-operator/deploy/rbac.yaml
-$ kubectl create -n <operator-namespace> -f helm-app-operator/deploy/operator.yaml
-```
-
-### Creating an instance of the example application
-
-After the `CustomResourceDefinition` and `ClusterServiceVersion-v1` resources for the new application have been applied, new instances of that app can be created:
-
-```sh
-$ kubectl create -n <operator-namespace> -f helm-app-operator/deploy/cr.yaml
-```
-
-Confirm the resources defined in the Helm Chart were created.
-
-[helm-sdk]: https://github.com/coreos/helm-app-operator-kit
+[helm-sdk]: ./
 [olm-repo]: https://github.com/operator-framework/operator-lifecycle-manager

--- a/examples/tomcat-operator/rbac.yaml
+++ b/examples/tomcat-operator/rbac.yaml
@@ -19,6 +19,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - namespaces
   verbs:
   - "*"
 - apiGroups:

--- a/examples/tomcat-operator/rbac.yaml
+++ b/examples/tomcat-operator/rbac.yaml
@@ -19,9 +19,14 @@ rules:
   - events
   - configmaps
   - secrets
-  - namespaces
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:

--- a/helm-app-operator/README.md
+++ b/helm-app-operator/README.md
@@ -140,7 +140,7 @@ We'll use a tomcat-operator as an example.
 
 6. Create Kubernetes resource files for your CRD, CR, RBAC rules and operator
 
-    The [examples](https://github.com/operator-framework/helm-app-operator-kit/tree/master/examples/tomcat-operator) directory has examples of each of these files that can be used for the tomcat-operator (or modified for other uses).
+    The [examples](../examples/tomcat-operator) directory has examples of each of these files that can be used for the tomcat-operator (or modified for other uses).
 
     ```bash
     cp -r $GOPATH/src/github.com/operator-framework/helm-app-operator-kit/examples/tomcat-operator/ deploy/

--- a/helm-app-operator/README.md
+++ b/helm-app-operator/README.md
@@ -1,0 +1,177 @@
+# Helm App Operator
+
+![Travis CI Build Status](https://travis-ci.org/operator-framework/helm-app-operator-kit.svg?branch=master "Travis CI Build Status")
+
+## Overview
+
+The Helm App Operator is a component of the [Operator Framework](https://github.com/operator-framework), an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way. Read more in the [introduction blog post](https://coreos.com/blog/introducing-operator-framework).
+
+The Helm App Operator makes it possible to leverage a pre-existing Helm chart to deploy Kubernetes resources as a unified application. It was inspired by the [Lostromos project](https://github.com/wpengine/lostromos). The underlying operator was created using the [operator-sdk][operator_sdk].
+
+## Quick Start
+
+This quick start guide walks through the process of building the Helm App Operator and extending it with an example Helm Chart.
+
+### Prerequisites
+
+- [dep][dep_tool] version v0.5.0+.
+- [go][go_tool] version v1.10+
+- [docker][docker_tool] version 17.03+
+- Access to a kubernetes v1.9.0+ cluster
+
+### Install the Operator SDK CLI
+
+First, checkout and install the operator-sdk CLI:
+
+```bash
+mkdir -p $GOPATH/src/github.com/operator-framework
+cd $GOPATH/src/github.com/operator-framework
+git clone https://github.com/operator-framework/operator-sdk.git
+cd operator-sdk
+make dep install
+```
+
+### Initial Setup
+
+Checkout this Helm App Operator repository:
+
+```bash
+cd $GOPATH/src/github.com/operator-framework
+git clone https://github.com/operator-framework/helm-app-operator-kit.git
+cd helm-app-operator-kit/helm-app-operator
+```
+
+Vendor the dependencies
+
+```bash
+make dep
+```
+
+### Build the operator base image
+
+Build the Helm App Operator base image and push it to a public registry, such as quay.io
+
+```bash
+export BASE_IMAGE=quay.io/example-inc/helm-app-operator:v0.0.1
+operator-sdk build $BASE_IMAGE
+docker push $BASE_IMAGE
+```
+
+## Build a customized operator
+
+Once you have a base image, the next step is to customize it to watch your custom resources and automate the deployment of your Helm Charts.
+
+### Configuration
+
+The operator can be configured with a YAML file and environment variables.
+
+#### YAML file
+
+The `watches.yaml` file allows you to configure the operator to manage one or more custom resources and Helm charts. By default, the operator will look for this file at `/opt/helm/watches.yaml`. This value can be overridden by the `HELM_CHART_WATCHES` environment variable.
+
+```yaml
+- group: apache.org
+  version: v1alpha1
+  kind: Tomcat
+  chart: /charts/tomcat
+```
+
+#### Environment variables
+
+Name               | Description
+-------------------|--------------------------------------------------------------------------------------
+HELM_CHART_WATCHES | The path to a configuration file that defines the operator watches (default: `/opt/helm/watches.yaml`).
+API_VERSION        | The `<group/version>` of the custom resource to watch.
+KIND               | The `<Kind>` of the custom resource to watch.
+HELM_CHART         | The path to a Helm chart directory
+WATCH_NAMESPACE    | The namespace in which the operator should watch for custom resource changes.
+
+
+**NOTE:** `API_VERSION`, `KIND`, and `HELM_CHART` are supported to maintain backwards compatibility with older versions of this operator. New projects should use the configuration file to configure the watched CRDs and Helm charts.
+
+### Create a new project for your customized operator
+
+We'll use a tomcat-operator as an example.
+
+1. Create a project directory:
+
+    ```bash
+    mkdir -p tomcat-operator && cd tomcat-operator
+    ```
+
+2. Download the tomcat helm chart into `tomcat-operator/helm-charts/`:
+
+    ```bash
+    mkdir helm-charts
+    wget -qO- https://storage.googleapis.com/kubernetes-charts/tomcat-0.1.0.tgz | tar vxz -C ./helm-charts
+    ```
+
+3. Create a watch configuration in `tomcat-operator/watches.yaml`:
+
+    ```bash
+    cat << EOF > watches.yaml
+    ---
+    - group: apache.org
+      version: v1alpha1
+      kind: Tomcat
+      chart: /helm-charts/tomcat
+    EOF
+    ```
+
+4. Create a Dockerfile:
+
+    ```bash
+    cat << EOF > Dockerfile
+    FROM $BASE_IMAGE
+    ADD watches.yaml /opt/helm/watches.yaml
+    ADD helm-charts /helm-charts
+    ENTRYPOINT ["/usr/local/bin/helm-app-operator"]
+    EOF
+    ```
+
+5. Build the tomcat-operator Docker image
+
+    ```bash
+    export BASE_IMAGE=quay.io/example-inc/helm-app-operator:v0.0.1
+    export TOMCAT_IMAGE=quay.io/example-inc/tomcat-operator:v0.0.1
+    docker build -t $TOMCAT_IMAGE .
+    docker push $TOMCAT_IMAGE
+    ```
+
+6. Create Kubernetes resource files for your CRD, CR, RBAC rules and operator
+
+    The [examples](https://github.com/operator-framework/helm-app-operator-kit/tree/master/examples/tomcat-operator) directory has examples of each of these files that can be used for the tomcat-operator (or modified for other uses).
+
+    ```bash
+    cp -r $GOPATH/src/github.com/operator-framework/helm-app-operator-kit/examples/tomcat-operator/ deploy/
+    sed "s|REPLACE_IMAGE|$TOMCAT_IMAGE|" deploy/operator.yaml.template > deploy/operator.yaml && rm deploy/operator.yaml.template
+    sed "s|REPLACE_IMAGE|$TOMCAT_IMAGE|" deploy/csv.yaml.template > deploy/csv.yaml && rm deploy/csv.yaml.template
+    ```
+
+7. Deploy the operator to your cluster
+
+    ```bash
+    export OPERATOR_NAMESPACE=default
+
+    # As a simple deployment
+    kubectl create -f deploy/crd.yaml
+    kubectl create -n $OPERATOR_NAMESPACE -f deploy/rbac.yaml
+    kubectl create -n $OPERATOR_NAMESPACE -f deploy/operator.yaml
+
+    # OR
+
+    # Using Operator Lifecycle Manager
+    kubectl create -f deploy/crd.yaml
+    kubectl create -n $OPERATOR_NAMESPACE -f deploy/csv.yaml
+    ```
+
+8. Create an instance of the Helm Chart
+
+    ```bash
+    kubectl create -n $OPERATOR_NAMESPACE -f deploy/cr.yaml
+    ```
+
+[dep_tool]:https://golang.github.io/dep/docs/installation.html
+[go_tool]:https://golang.org/dl/
+[docker_tool]:https://docs.docker.com/install/
+[operator_sdk]:https://github.com/operator-framework/operator-sdk

--- a/helm-app-operator/test/memcached-operator/deploy/rbac.yaml
+++ b/helm-app-operator/test/memcached-operator/deploy/rbac.yaml
@@ -19,9 +19,14 @@ rules:
   - events
   - configmaps
   - secrets
-  - namespaces
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
**Description of the change:**
Adding a new README.md in the helm-app-operator directory that documents more details about the build and configuration features of the operator, along with a simple tomcat-operator example.

Updating the root README.md to simplify it and point to the examples/tomcat-operator example and to the helm-app-operator README for more details.

Fixing a broken RBAC rule in the tomcat-operator example that prevents the example operator from running correctly.

**Motivation for the change:**
With many changes over the past month, the documentation for helm-app-operator-kit needed to be updated. The refactoring of the documentation is also a step towards integrating the helm-app-operator into operator-sdk.

**Rendered markdown of proposed changes:**
https://github.com/joelanford/helm-app-operator-kit/tree/readme