### PR TITLE
Split manager into separate release functions

### DIFF
--- a/helm-app-operator/pkg/helm/controller/reconcile.go
+++ b/helm-app-operator/pkg/helm/controller/reconcile.go
@@ -123,7 +123,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 
 		status.SetRelease(installedRelease)
 		status.SetPhase(types.PhaseApplied, types.ReasonApplySuccessful, installedRelease.GetInfo().GetStatus().GetNotes())
-		err = r.updateResource(o, status)
+		err = r.updateResourceStatus(o, status)
 		return reconcile.Result{RequeueAfter: r.ResyncPeriod}, err
 	}
 
@@ -138,7 +138,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 
 		status.SetRelease(updatedRelease)
 		status.SetPhase(types.PhaseApplied, types.ReasonApplySuccessful, updatedRelease.GetInfo().GetStatus().GetNotes())
-		err = r.updateResource(o, status)
+		err = r.updateResourceStatus(o, status)
 		return reconcile.Result{RequeueAfter: r.ResyncPeriod}, err
 	}
 
@@ -152,7 +152,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	return reconcile.Result{RequeueAfter: r.ResyncPeriod}, nil
 }
 
-func (r HelmOperatorReconciler) updateResource(o *unstructured.Unstructured, status *types.HelmAppStatus) error {
+func (r HelmOperatorReconciler) updateResourceStatus(o *unstructured.Unstructured, status *types.HelmAppStatus) error {
 	o.Object["status"] = status
 	return r.Client.Update(context.TODO(), o)
 }

--- a/helm-app-operator/pkg/helm/controller/reconcile.go
+++ b/helm-app-operator/pkg/helm/controller/reconcile.go
@@ -79,7 +79,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	status := types.StatusFor(o)
 	releaseName := manager.ReleaseName()
 
-	if err := manager.Sync(); err != nil {
+	if err := manager.Sync(context.TODO()); err != nil {
 		logrus.Errorf("failed to sync release for %s release=%s: %s", util.ResourceString(o), releaseName, err)
 		return reconcile.Result{}, err
 	}
@@ -90,7 +90,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, nil
 		}
 
-		uninstalledRelease, err := manager.UninstallRelease()
+		uninstalledRelease, err := manager.UninstallRelease(context.TODO())
 		if err != nil && err != release.ErrNotFound {
 			logrus.Errorf("failed to uninstall release for %s release=%s: %s", util.ResourceString(o), releaseName, err)
 			return reconcile.Result{}, err
@@ -113,7 +113,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	if !manager.IsInstalled() {
-		installedRelease, err := manager.InstallRelease()
+		installedRelease, err := manager.InstallRelease(context.TODO())
 		if err != nil {
 			logrus.Errorf("failed to install release for %s release=%s: %s", util.ResourceString(o), releaseName, err)
 			return reconcile.Result{}, err
@@ -128,7 +128,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	if manager.IsUpdateRequired() {
-		previousRelease, updatedRelease, err := manager.UpdateRelease()
+		previousRelease, updatedRelease, err := manager.UpdateRelease(context.TODO())
 		if err != nil {
 			logrus.Errorf("failed to update release for %s release=%s: %s", util.ResourceString(o), releaseName, err)
 			return reconcile.Result{}, err
@@ -142,7 +142,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{RequeueAfter: r.ResyncPeriod}, err
 	}
 
-	_, err = manager.ReconcileRelease()
+	_, err = manager.ReconcileRelease(context.TODO())
 	if err != nil {
 		logrus.Errorf("failed to reconcile release for %s release=%s: %s", util.ResourceString(o), releaseName, err)
 		return reconcile.Result{}, err

--- a/helm-app-operator/pkg/helm/release/manager.go
+++ b/helm-app-operator/pkg/helm/release/manager.go
@@ -416,14 +416,13 @@ func processRequirements(chart *cpb.Chart, values *cpb.Config) error {
 	return nil
 }
 
-func shortenUID(uid apitypes.UID) (shortUID string) {
+func shortenUID(uid apitypes.UID) string {
 	u := uuid.Parse(string(uid))
 	uidBytes, err := u.MarshalBinary()
 	if err != nil {
-		shortUID = strings.Replace(string(uid), "-", "", -1)
+		return strings.Replace(string(uid), "-", "", -1)
 	}
-	shortUID = strings.ToLower(base36.EncodeBytes(uidBytes))
-	return
+	return strings.ToLower(base36.EncodeBytes(uidBytes))
 }
 
 func (m manager) getDeployedRelease() (*rpb.Release, error) {


### PR DESCRIPTION
**Description of change:**
Expanding the `Manager` interface to include more fine-grained methods for release management, and updating `HelmOperatorReconciler` to use them.

**Motivation for change:**
The existing `manager.ReconcileRelease` method hides much of the granularity of what is involved in reconciling a resource, which makes status updates cumbersome and coupled to the Manager. This change gives the `HelmOperatorReconciler` more responsibility, but also more control and visibility, which will enable future updates to provide improved logging and status updates.

This PR also fixed a bug with the `shortenUID` function.