### PR TITLE
Update status after failures and use conditions

### DIFF
--- a/helm-app-operator/hack/tests/e2e-helm.sh
+++ b/helm-app-operator/hack/tests/e2e-helm.sh
@@ -78,14 +78,14 @@ fi
 # create CR
 kubectl create -f deploy/cr.yaml
 trap_add 'kubectl delete --ignore-not-found -f ${DIR1}/deploy/cr.yaml' EXIT
-if ! timeout 1m bash -c -- 'until kubectl get memcacheds.helm.example.com my-test-app -o jsonpath="{..status.release.info.status.code}" | grep 1; do sleep 1; done';
+if ! timeout 1m bash -c -- 'until kubectl get memcacheds.helm.example.com my-test-app -o jsonpath="{..status.conditions[0].release.info.status.code}" | grep 1; do sleep 1; done';
 then
     kubectl describe crds
     kubectl logs deployment/memcached-operator
     exit 1
 fi
 
-release_name=$(kubectl get memcacheds.helm.example.com my-test-app -o jsonpath="{..status.release.name}")
+release_name=$(kubectl get memcacheds.helm.example.com my-test-app -o jsonpath="{..status.conditions[0].release.name}")
 memcached_statefulset=$(kubectl get statefulset -l release=${release_name} -o jsonpath="{..metadata.name}")
 kubectl patch statefulset ${memcached_statefulset} -p '{"spec":{"updateStrategy":{"type":"RollingUpdate"}}}'
 if ! timeout 1m kubectl rollout status statefulset/${memcached_statefulset};

--- a/helm-app-operator/pkg/helm/engine/ownerref.go
+++ b/helm-app-operator/pkg/helm/engine/ownerref.go
@@ -50,6 +50,7 @@ func (o *OwnerRefEngine) Render(chart *chart.Chart, values chartutil.Values) (ma
 	ownedRenderedFiles := map[string]string{}
 	for fileName, renderedFile := range rendered {
 		if !strings.HasSuffix(fileName, ".yaml") {
+			ownedRenderedFiles[fileName] = renderedFile
 			continue
 		}
 		logrus.Debugf("adding ownerrefs to file: %s", fileName)

--- a/helm-app-operator/pkg/helm/internal/types/types.go
+++ b/helm-app-operator/pkg/helm/internal/types/types.go
@@ -38,32 +38,41 @@ type HelmApp struct {
 
 type HelmAppSpec map[string]interface{}
 
-type ResourcePhase string
+type HelmAppConditionType string
+type ConditionStatus string
+type HelmAppConditionReason string
+
+type HelmAppCondition struct {
+	Type    HelmAppConditionType   `json:"type"`
+	Status  ConditionStatus        `json:"status"`
+	Reason  HelmAppConditionReason `json:"reason,omitempty"`
+	Message string                 `json:"message,omitempty"`
+	Release *release.Release       `json:"release,omitempty"`
+
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+}
 
 const (
-	PhaseNone     ResourcePhase = ""
-	PhaseApplying ResourcePhase = "Applying"
-	PhaseApplied  ResourcePhase = "Applied"
-	PhaseFailed   ResourcePhase = "Failed"
-)
+	ConditionInitializing   HelmAppConditionType = "Initializing"
+	ConditionDeployed       HelmAppConditionType = "Deployed"
+	ConditionReleaseFailed  HelmAppConditionType = "ReleaseFailed"
+	ConditionIrreconcilable HelmAppConditionType = "Irreconcilable"
 
-type ConditionReason string
+	StatusTrue    ConditionStatus = "True"
+	StatusFalse   ConditionStatus = "False"
+	StatusUnknown ConditionStatus = "Unknown"
 
-const (
-	ReasonUnknown               ConditionReason = "Unknown"
-	ReasonCustomResourceAdded   ConditionReason = "CustomResourceAdded"
-	ReasonCustomResourceUpdated ConditionReason = "CustomResourceUpdated"
-	ReasonApplySuccessful       ConditionReason = "ApplySuccessful"
-	ReasonApplyFailed           ConditionReason = "ApplyFailed"
+	ReasonInstallSuccessful   HelmAppConditionReason = "InstallSuccessful"
+	ReasonUpdateSuccessful    HelmAppConditionReason = "UpdateSuccessful"
+	ReasonUninstallSuccessful HelmAppConditionReason = "UninstallSuccessful"
+	ReasonInstallError        HelmAppConditionReason = "InstallError"
+	ReasonUpdateError         HelmAppConditionReason = "UpdateError"
+	ReasonReconcileError      HelmAppConditionReason = "ReconcileError"
+	ReasonUninstallError      HelmAppConditionReason = "UninstallError"
 )
 
 type HelmAppStatus struct {
-	Release            *release.Release `json:"release"`
-	Phase              ResourcePhase    `json:"phase"`
-	Reason             ConditionReason  `json:"reason,omitempty"`
-	Message            string           `json:"message,omitempty"`
-	LastUpdateTime     metav1.Time      `json:"lastUpdateTime,omitempty"`
-	LastTransitionTime metav1.Time      `json:"lastTransitionTime,omitempty"`
+	Conditions []HelmAppCondition `json:"conditions"`
 }
 
 func (s *HelmAppStatus) ToMap() (map[string]interface{}, error) {
@@ -76,37 +85,53 @@ func (s *HelmAppStatus) ToMap() (map[string]interface{}, error) {
 	return out, nil
 }
 
-// SetPhase takes a custom resource status and returns the updated status, without updating the resource in the cluster.
-func (s *HelmAppStatus) SetPhase(phase ResourcePhase, reason ConditionReason, message string) *HelmAppStatus {
-	s.LastUpdateTime = metav1.Now()
-	if s.Phase != phase {
-		s.Phase = phase
-		s.LastTransitionTime = metav1.Now()
+// SetCondition sets a condition on the status object. If the condition already
+// exists, it will be replaced. SetCondition does not update the resource in
+// the cluster.
+func (s *HelmAppStatus) SetCondition(condition HelmAppCondition) *HelmAppStatus {
+	now := metav1.Now()
+	for i := range s.Conditions {
+		if s.Conditions[i].Type == condition.Type {
+			if s.Conditions[i].Status != condition.Status {
+				condition.LastTransitionTime = now
+			} else {
+				condition.LastTransitionTime = s.Conditions[i].LastTransitionTime
+			}
+			s.Conditions[i] = condition
+			return s
+		}
 	}
-	s.Message = message
-	s.Reason = reason
+
+	// If the condition does not exist,
+	// initialize the lastTransitionTime
+	condition.LastTransitionTime = now
+	s.Conditions = append(s.Conditions, condition)
 	return s
 }
 
-// SetRelease takes a release object and adds or updates the release on the status object
-func (s *HelmAppStatus) SetRelease(release *release.Release) *HelmAppStatus {
-	s.Release = release
+// RemoveCondition removes the condition with the passed condition type from
+// the status object. If the condition is not already present, the returned
+// status object is returned unchanged. RemoveCondition does not update the
+// resource in the cluster.
+func (s *HelmAppStatus) RemoveCondition(conditionType HelmAppConditionType) *HelmAppStatus {
+	for i := range s.Conditions {
+		if s.Conditions[i].Type == conditionType {
+			s.Conditions = append(s.Conditions[:i], s.Conditions[i+1:]...)
+			return s
+		}
+	}
 	return s
 }
 
 // StatusFor safely returns a typed status block from a custom resource.
 func StatusFor(cr *unstructured.Unstructured) *HelmAppStatus {
-	switch cr.Object["status"].(type) {
+	switch s := cr.Object["status"].(type) {
 	case *HelmAppStatus:
-		return cr.Object["status"].(*HelmAppStatus)
+		return s
 	case map[string]interface{}:
 		var status *HelmAppStatus
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(cr.Object["status"].(map[string]interface{}), &status); err != nil {
-			return &HelmAppStatus{
-				Phase:   PhaseFailed,
-				Reason:  ReasonApplyFailed,
-				Message: err.Error(),
-			}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(s, &status); err != nil {
+			return &HelmAppStatus{}
 		}
 		return status
 	default:

--- a/helm-app-operator/pkg/helm/internal/types/types_test.go
+++ b/helm-app-operator/pkg/helm/internal/types/types_test.go
@@ -30,15 +30,38 @@ const (
 
 var now = metav1.Now()
 
-func TestSetPhase(t *testing.T) {
-	newStatus, err := newTestStatus().SetPhase(PhaseApplying, ReasonCustomResourceUpdated, "working on it").ToMap()
+func TestSetCondition(t *testing.T) {
+	message := "uninstall was successful"
+	releaseName := "TestRelease"
+	newStatus, err := newTestStatus().SetCondition(HelmAppCondition{
+		Type:    ConditionDeployed,
+		Status:  StatusFalse,
+		Reason:  ReasonUninstallSuccessful,
+		Message: message,
+		Release: &release.Release{Name: releaseName},
+	}).ToMap()
 	assert.NoError(t, err)
 
-	assert.Equal(t, string(PhaseApplying), newStatus["phase"])
-	assert.Equal(t, string(ReasonCustomResourceUpdated), newStatus["reason"])
-	assert.Equal(t, "working on it", newStatus["message"])
-	assert.NotEqual(t, metav1.Now(), newStatus["lastUpdateTime"])
-	assert.NotEqual(t, metav1.Now(), newStatus["lastTransitionTime"])
+	resource := newTestResource()
+	resource.Object["status"] = newStatus
+	actual := StatusFor(resource)
+
+	assert.Equal(t, ConditionDeployed, actual.Conditions[0].Type)
+	assert.Equal(t, StatusFalse, actual.Conditions[0].Status)
+	assert.Equal(t, ReasonUninstallSuccessful, actual.Conditions[0].Reason)
+	assert.Equal(t, message, actual.Conditions[0].Message)
+	assert.Equal(t, releaseName, actual.Conditions[0].Release.Name)
+	assert.NotEqual(t, metav1.Now(), actual.Conditions[0].LastTransitionTime)
+}
+func TestRemoveCondition(t *testing.T) {
+	newStatus, err := newTestStatus().RemoveCondition(ConditionDeployed).ToMap()
+	assert.NoError(t, err)
+
+	resource := newTestResource()
+	resource.Object["status"] = newStatus
+	actual := StatusFor(resource)
+
+	assert.Empty(t, actual.Conditions)
 }
 
 func TestStatusForEmpty(t *testing.T) {
@@ -52,9 +75,7 @@ func TestStatusForFilled(t *testing.T) {
 	expectedResource.Object["status"] = newTestStatus()
 	status := StatusFor(expectedResource)
 
-	assert.EqualValues(t, newTestStatus().Phase, status.Phase)
-	assert.EqualValues(t, newTestStatus().Reason, status.Reason)
-	assert.EqualValues(t, newTestStatus().Message, status.Message)
+	assert.EqualValues(t, newTestStatus().Conditions, status.Conditions)
 }
 
 func TestStatusForFilledRaw(t *testing.T) {
@@ -62,16 +83,12 @@ func TestStatusForFilledRaw(t *testing.T) {
 	expectedResource.Object["status"] = newTestStatusRaw()
 	status := StatusFor(expectedResource)
 
-	assert.EqualValues(t, newTestStatus().Phase, status.Phase)
-	assert.EqualValues(t, newTestStatus().Reason, status.Reason)
-	assert.EqualValues(t, newTestStatus().Message, status.Message)
-}
-
-func TestSetRelease(t *testing.T) {
-	releaseName := "TestRelease"
-	release := release.Release{Name: releaseName}
-	newStatus := newTestStatus().SetRelease(&release)
-	assert.EqualValues(t, newStatus.Release.Name, releaseName)
+	assert.Equal(t, ConditionDeployed, status.Conditions[0].Type)
+	assert.Equal(t, StatusTrue, status.Conditions[0].Status)
+	assert.Equal(t, ReasonInstallSuccessful, status.Conditions[0].Reason)
+	assert.Equal(t, "some message", status.Conditions[0].Message)
+	assert.Equal(t, "SomeRelease", status.Conditions[0].Release.Name)
+	assert.NotEqual(t, metav1.Now(), status.Conditions[0].LastTransitionTime)
 }
 
 func newTestResource() *unstructured.Unstructured {
@@ -94,20 +111,30 @@ func newTestResource() *unstructured.Unstructured {
 
 func newTestStatus() *HelmAppStatus {
 	return &HelmAppStatus{
-		Phase:              PhaseApplied,
-		Reason:             ReasonApplySuccessful,
-		Message:            "some message",
-		LastUpdateTime:     now,
-		LastTransitionTime: now,
+		Conditions: []HelmAppCondition{
+			{
+				Type:               ConditionDeployed,
+				Status:             StatusTrue,
+				Reason:             ReasonInstallSuccessful,
+				Message:            "some message",
+				Release:            &release.Release{Name: "SomeRelease"},
+				LastTransitionTime: now,
+			},
+		},
 	}
 }
 
 func newTestStatusRaw() map[string]interface{} {
 	return map[string]interface{}{
-		"phase":              PhaseApplied,
-		"reason":             ReasonApplySuccessful,
-		"message":            "some message",
-		"lastUpdateTime":     now.UTC(),
-		"lastTransitionTime": now.UTC(),
+		"conditions": []map[string]interface{}{
+			{
+				"type":               "Deployed",
+				"status":             "True",
+				"reason":             "InstallSuccessful",
+				"message":            "some message",
+				"release":            map[string]interface{}{"name": "SomeRelease"},
+				"lastTransitionTime": now.UTC(),
+			},
+		},
 	}
 }

--- a/helm-app-operator/pkg/helm/release/manager.go
+++ b/helm-app-operator/pkg/helm/release/manager.go
@@ -147,12 +147,20 @@ func (m *manager) Sync(ctx context.Context) error {
 }
 
 func (m manager) syncReleaseStatus(status types.HelmAppStatus) error {
-	if status.Release == nil {
+	var release *rpb.Release
+	for _, condition := range status.Conditions {
+		if condition.Type == types.ConditionDeployed && condition.Status == types.StatusTrue {
+			release = condition.Release
+			break
+		}
+	}
+
+	if release == nil {
 		return nil
 	}
 
-	name := status.Release.GetName()
-	version := status.Release.GetVersion()
+	name := release.GetName()
+	version := release.GetVersion()
 	_, err := m.storageBackend.Get(name, version)
 	if err == nil {
 		return nil
@@ -161,7 +169,7 @@ func (m manager) syncReleaseStatus(status types.HelmAppStatus) error {
 	if !notFoundErr(err) {
 		return err
 	}
-	return m.storageBackend.Create(status.Release)
+	return m.storageBackend.Create(release)
 }
 
 func notFoundErr(err error) bool {


### PR DESCRIPTION
**Description of change:**
* Updates the `HelmAppStatus` to use `Conditions` as described here.
* Updates the `Reconcile` method to make more granular status updates, for example during initialization and after failures

**Motivation for change:**
See #59 